### PR TITLE
build fix: using npm@4.6.1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
         source: https://github.com/wekan/wekan/releases/download/v0.24/wekan-0.24.tar.gz
         source-subdir: programs/server
         plugin: nodejs
-        node-packages: [npm]
+        node-packages: [npm@4.6.1]
         node-engine: 4.8.1
         build-packages:
             - python


### PR DESCRIPTION
fixing snap craft build for version 0.24
Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>